### PR TITLE
Document Go modules compatibility and add SemVer tag v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ While `netchan` currently enables data transfer across machines, it does not yet
 
 For more details on implementation, refer to the [Documentation](wiki/README.md).
 
+## Installation
+
+```bash
+go get github.com/matveynator/netchan@latest
+```
+
+The module path for imports is:
+
+```go
+import "github.com/matveynator/netchan"
+```
+
+For release/versioning details, see [Go Modules compatibility](docs/go-modules.md).
+
 ## netchan Usage Example
 
 This guide provides a basic example of how to use the `netchan` package for setting up simple server-client communication in Go. Note that `message` can be any type of data, including a Go channel (`chan`).

--- a/docs/go-modules.md
+++ b/docs/go-modules.md
@@ -1,0 +1,23 @@
+# Go Modules compatibility
+
+This repository is a single-module Go library.
+
+## Module path
+
+The canonical module path is:
+
+```txt
+github.com/matveynator/netchan
+```
+
+Consumers should import the package as:
+
+```go
+import "github.com/matveynator/netchan"
+```
+
+## Versioning policy
+
+Releases are published with SemVer tags in the `vMAJOR.MINOR.PATCH` format.
+
+`@latest` resolves to the highest SemVer tag, which guarantees deterministic installation through Go modules and public proxies.


### PR DESCRIPTION
### Motivation

- Ensure consumers can reliably install the package with `go get github.com/matveynator/netchan@latest` by clarifying module path and versioning policy.
- Provide explicit guidance for import path and SemVer usage so public proxies and Go modules resolve `@latest` deterministically.
- Avoid changing library code while enabling other projects to import `github.com/matveynator/netchan` without ambiguity.

### Description

- Added `docs/go-modules.md` that documents the canonical module path and a SemVer-based versioning policy.
- Updated `README.md` with an `Installation` section that shows `go get github.com/matveynator/netchan@latest`, the import path, and a link to the new module compatibility doc.
- Published an annotated SemVer tag `v0.1.0` so `@latest` resolves to a valid release for Go modules tooling without modifying package source files.

### Testing

- Ran `go test .` which passed (package has no test files so it completed successfully).
- Ran `go test ./...` which failed due to duplicate `main`/symbol declarations in the example programs and is unrelated to module metadata changes.
- Ran `go mod tidy` which completed successfully and did not introduce dependency changes.
- Attempted `GOPROXY=https://proxy.golang.org go list -m -json github.com/matveynator/netchan@latest` which could not be verified here due to an external `403` proxy/CONNECT restriction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac5a903fac8332bb622acf24824f12)